### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -30,8 +30,8 @@ class ItemsController < ApplicationController
   #   end
   # end
 
-  def edit
-  end
+  # def edit
+  # end
 
   def show
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,5 @@
 class ItemsController < ApplicationController
+  before_action :set_item, only: [:edit, :show]
   # ログインしていないユーザーが出品ボタン押下しても、ログインへ連れて行かれる
   before_action :move_to_new, only: [:new,]
 
@@ -19,10 +20,40 @@ class ItemsController < ApplicationController
     @items = Item.all.order("created_at DESC")
   end
 
+  def destroy
+    @item = Item.find(params[:id])
+    @item.destroy
+    if @item.destroy
+      redirect_to root_path
+    else
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def show
+  end
+
+  def update
+    @item = Item.find(params[:id])
+    @item.update(item_params)
+    if @item.save
+      redirect_to item_path(@item)
+    else
+      render :new
+    end
+  end
+
   private
 
   def item_params
     params.require(:item).permit(:name, :detail, :category_id, :item_status_id, :shipping_fee_id, :shipping_location_id, :shipping_date_id, :price, :image).merge(user_id: current_user.id)
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 
   # ログインしていないユーザーが出品ボタン押下しても、ログインへ連れて行かれる

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,15 +20,15 @@ class ItemsController < ApplicationController
     @items = Item.all.order("created_at DESC")
   end
 
-  def destroy
-    @item = Item.find(params[:id])
-    @item.destroy
-    if @item.destroy
-      redirect_to root_path
-    else
-      render :new
-    end
-  end
+  # def destroy
+  #   @item = Item.find(params[:id])
+  #   @item.destroy
+  #   if @item.destroy
+  #     redirect_to root_path
+  #   else
+  #     render :new
+  #   end
+  # end
 
   def edit
   end
@@ -36,15 +36,15 @@ class ItemsController < ApplicationController
   def show
   end
 
-  def update
-    @item = Item.find(params[:id])
-    @item.update(item_params)
-    if @item.save
-      redirect_to item_path(@item)
-    else
-      render :new
-    end
-  end
+  # def update
+  #   @item = Item.find(params[:id])
+  #   @item.update(item_params)
+  #   if @item.save
+  #     redirect_to item_path(@item)
+  #   else
+  #     render :new
+  #   end
+  # end
 
   private
 

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,7 +7,7 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with model: @item, id: 'new_item', local: true do |f| %>
+    <%# <%= form_with model: @item, id: 'new_item', local: true do |f| %>
     <% render 'shared/error_messages', model: f.object %>
 
     <%# 出品画像 %>
@@ -70,17 +70,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_fee_id, ShippingFee.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%# <%= f.collection_select(:shipping_fee_id, ShippingFee.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_location_id, ShippingLocation.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%# <%= f.collection_select(:shipping_location_id, ShippingLocation.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_date_id, ShippingDate.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%# <%= f.collection_select(:shipping_date_id, ShippingDate.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -98,7 +98,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%# <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,12 +7,8 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
-
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%= form_with model: (@item, url: item_path, id: 'edit_item', class: 'registration-main', local: true ) do |f| %>
+    <%= form_with model: @item, id: 'new_item', local: true do |f| %>
     <% render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 出品画像 %>
     <div class="img-upload">
@@ -26,11 +22,8 @@ app/assets/stylesheets/items/new.css %>
         </p>
         <%= f.file_field :image, id:"item-image" %>
       </div>
-      <%#ActiveStorage導入後に下記追記 %>
-      <%= image_tag @item.image.variant(resize:'500x500'), class: 'item-image' if @item.image.attached? %>
     </div>
     <%# /出品画像 %>
-
     <%# 商品名と商品説明 %>
     <div class="new-items">
       <div class="weight-bold-text">
@@ -144,8 +137,8 @@ app/assets/stylesheets/items/new.css %>
     <%# /注意書き %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
-      <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', root_path, class:"back-btn" %>
+      <%= f.submit "変更する", class:"sell-btn" %>
+      <%=link_to 'もどる', item_path(@item.id), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -141,15 +141,15 @@
             <%= image_tag item.image.variant(resize_to_fill: [200, 200]) %>
 
             <%# 商品が売れていればsold outの表示 %>
-            <% if @purchases.present? %>
+            <%# <% if @purchases.present? %>
 
-              <div class='sold-out'>
-                <span>Sold Out!!</span>
-              </div>
+              <%# <div class='sold-out'> %>
+                <%# <span>Sold Out!!</span> %>
+              <%# </div> %>
               
-            <% else %>
+            <%# <% else %>
 
-            <% end %>
+            <%# <% end %>
             <%# //商品が売れていればsold outの表示 %>
 
           </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -136,7 +136,7 @@
 
         <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
         <li class='list'>
-          <%= link_to "#" do %>
+          <%= link_to item_path(item.id) do %>
           <div class='item-img-content'>
             <%= image_tag item.image.variant(resize_to_fill: [200, 200]) %>
 
@@ -175,7 +175,7 @@
         <%# 商品がない場合のダミー %>
         <%# 商品がある場合は表示されないようにしましょう %>
         <li class='list'>
-          <%= link_to '#' do %>
+          <%= link_to item_path do %>
           <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
           <div class='item-info'>
             <h3 class='item-name'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -105,7 +105,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,19 +4,19 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image.variant(resize_to_fill: [500, 500])  ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outの表示をしましょう。 %>
-      <div class='sold-out'>
+      <%# <div class='sold-out'>
         <span>Sold Out!!</span>
-      </div>
+      </div> %>
       <%# //商品が売れている場合は、sold outの表示をしましょう。 %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
         (税込) 送料込み
@@ -24,45 +24,49 @@
     </div>
 
     <%# ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう%>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to '商品の編集', edit_item_path(@item.id), class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', item_path, method: :delete, class:'item-destroy' %>
+    <% else %>
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <%# <% if user_signed_in? %>
+        <%# <%= link_to '購入画面に進む', "カード決済画面" ,class:"item-red-btn"%>
+      <%# <% else %>
+        <%= link_to '購入画面に進む', user_session_path ,class:"item-red-btn" %>
+      <%# <% end %>
+      <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
     <%# // ログインしているユーザと出品しているユーザが同一人物である時、商品の編集と削除を表示にしましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.detail %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.item_status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.shipping_location.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_date.name %></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
#What
商品詳細表示機能を実装

#Why
商品詳細表示機能をつくる必要があったため

#画像
- ログアウト状態でも商品詳細ページを閲覧できること
https://gyazo.com/84823a392c8fafa151085e0d4598ef06

- 出品者にしか商品の編集・削除のリンクが踏めないようになっていること
https://gyazo.com/12f2e9f29a5ea4cd325229d2cb2a63f1

- 出品者以外（且つログインしたユーザー）のみ商品購入のリンクが踏めること
https://gyazo.com/fc059d8aeda6a8b9a295eeb376d6bd37

- 商品出品時に登録した情報が見られるようになっていること
https://gyazo.com/a76f9950735d098c2d0754731c4876c1