### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :set_item, only: [:edit, :show]
   # ログインしていないユーザーが出品ボタン押下しても、ログインへ連れて行かれる
-  before_action :move_to_new, only: [:new,]
+  before_action :move_to_new, only: [:new]
 
   def new
     @item = Item.new
@@ -17,7 +17,7 @@ class ItemsController < ApplicationController
   end
 
   def index
-    @items = Item.all.order("created_at DESC")
+    @items = Item.all.order('created_at DESC')
   end
 
   # def destroy

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :set_item, only: [:edit, :show]
+  before_action :set_item, only: [:edit, :show, :update]
   # ログインしていないユーザーが出品ボタン押下しても、ログインへ連れて行かれる
   before_action :move_to_new, only: [:new]
 
@@ -30,19 +30,17 @@ class ItemsController < ApplicationController
   #   end
   # end
 
-  # def edit
-  # end
+  def edit
+  end
 
   def show
   end
 
   def update
-    @item = Item.find(params[:id])
-    @item.update(item_params)
-    if @item.save
+    if @item.update(item_params)
       redirect_to item_path(@item)
     else
-      render :new
+      render :edit
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,15 +36,15 @@ class ItemsController < ApplicationController
   def show
   end
 
-  # def update
-  #   @item = Item.find(params[:id])
-  #   @item.update(item_params)
-  #   if @item.save
-  #     redirect_to item_path(@item)
-  #   else
-  #     render :new
-  #   end
-  # end
+  def update
+    @item = Item.find(params[:id])
+    @item.update(item_params)
+    if @item.save
+      redirect_to item_path(@item)
+    else
+      render :new
+    end
+  end
 
   private
 

--- a/app/models/shipping_location.rb
+++ b/app/models/shipping_location.rb
@@ -1,6 +1,6 @@
 class ShippingLocation < ActiveHash::Base
   self.data = [
-    { id: 1, name: '---' }, 
+    { id: 1, name: '---' },
     { id: 2, name: '北海道' }, { id: 3, name: '青森県' }, { id: 4, name: '岩手県' },
     { id: 5, name: '宮城県' }, { id: 6, name: '秋田県' }, { id: 7, name: '山形県' },
     { id: 8, name: '福島県' }, { id: 9, name: '茨城県' }, { id: 10, name: '栃木県' },

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,7 +7,7 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%# <%= form_with model: @item, id: 'new_item', local: true do |f| %>
+    <%= form_with model: @item, id: 'new_item', local: true do |f| %>
     <% render 'shared/error_messages', model: f.object %>
 
     <%# 出品画像 %>
@@ -70,17 +70,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:shipping_fee_id, ShippingFee.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_fee_id, ShippingFee.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:shipping_location_id, ShippingLocation.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:shipping_location_id, ShippingLocation.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:shipping_date_id, ShippingDate.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_date_id, ShippingDate.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -98,7 +98,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%# <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -138,7 +138,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する", class:"sell-btn" %>
-      <%=link_to 'もどる', item_path(@item.id), class:"back-btn" %>
+      <%= link_to 'もどる', item_path(@item.id), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,8 +7,9 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with model: @item, id: 'new_item', local: true do |f| %>
-    <% render 'shared/error_messages', model: f.object %>
+
+    <%= form_with model: @item, id: 'edit_item', local: true do |f| %>
+    <%= render 'shared/error_messages', model: f.object %>
 
     <%# 出品画像 %>
     <div class="img-upload">

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :item do
     name { 'あいうえお' }
     detail { 'あいうえお' }
-    price { 123456 }
+    price { 123_456 }
     category_id { Faker::Number.between(from: 2, to: 11) }
     item_status_id { Faker::Number.between(from: 2, to: 7) }
     shipping_fee_id { Faker::Number.between(from: 2, to: 3) }

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Item, type: :model do
     end
 
     it 'priceが¥300~¥9,999,999の間であること(上限)' do
-      @item.price = 10000000
+      @item.price = 10_000_000
       @item.valid?
       expect(@item.errors.full_messages).to include('Price is not included in the list')
     end


### PR DESCRIPTION
#What
商品情報編集機能実装

#Why
商品情報編集機能があると便利であるため

#画像
- 商品情報（商品画像・商品名・商品の状態など）を変更できること
- 何も編集せずに更新をしても画像無しの商品にならない
https://gyazo.com/6bfab2c8a714a6da732916c63898ba72

- 出品者だけが編集ページに遷移できること
- 商品出品時とほぼ同じUIで編集機能が実装できること
- 商品名やカテゴリーの情報など、すでに登録されている商品情報は編集画面を開いた時点で表示されること
https://gyazo.com/ac24e6677355142cb3d495c26ee25bcb

- エラーハンドリングができていること
https://gyazo.com/8b4c85f40dc94d2043e87bde2df18c71