### PR TITLE
デプロイの為の追加修正5

### DIFF
--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -175,7 +175,7 @@
         <%# 商品がない場合のダミー %>
         <%# 商品がある場合は表示されないようにしましょう %>
         <li class='list'>
-          <%= link_to item_path(@items.id) do %>
+          <%= link_to "#" do %>
           <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
           <div class='item-info'>
             <h3 class='item-name'>


### PR DESCRIPTION
#What
5度目のデプロイの為の追加修正

#Why
そもそもリンクを飛ばす必要がないところにlink_toメソッドを記入していたため。