### PR TITLE
商品削除画面の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :set_item, only: [:edit, :show, :update]
+  before_action :set_item, only: [:edit, :show, :update, :destroy]
   # ログインしていないユーザーが出品ボタン押下しても、ログインへ連れて行かれる
   before_action :move_to_new, only: [:new]
 
@@ -21,7 +21,6 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    @item = Item.find(params[:id])
     @item.destroy
     if @item.destroy
       redirect_to root_path

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,15 +20,15 @@ class ItemsController < ApplicationController
     @items = Item.all.order('created_at DESC')
   end
 
-  # def destroy
-  #   @item = Item.find(params[:id])
-  #   @item.destroy
-  #   if @item.destroy
-  #     redirect_to root_path
-  #   else
-  #     render :new
-  #   end
-  # end
+  def destroy
+    @item = Item.find(params[:id])
+    @item.destroy
+    if @item.destroy
+      redirect_to root_path
+    else
+      render :edit
+    end
+  end
 
   
   def edit

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
     <% if user_signed_in? && current_user.id == @item.user_id %>
       <%= link_to '商品の編集', edit_item_path(@item.id), class: "item-red-btn" %>
       <p class='or-text'>or</p>
-      <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
+      <%= link_to '削除', item_path, method: :delete, class:'item-destroy' %>
     <% else %>
       <%# 商品が売れていない場合はこちらを表示しましょう %>
       <%# <% if user_signed_in? %>


### PR DESCRIPTION
#What
商品削除機能の追加

#Why
出品者の気が変わって、商品を削除したくなるかもしれないから。

#画像

出品者だけが商品情報を削除できること
https://gyazo.com/2ab65e752460180367d0ac5e4c9bf61c

削除後
https://gyazo.com/8eae631d2be6e2f21571a85cbe165d4b
https://gyazo.com/833078f174922da7d14e1bd59539f755

『いちご』がログイン中は、他の出品者の商品詳細ページに行っても削除ボタンは表示されない
https://gyazo.com/0987aff84088d0efacda50adad2870e3

ログインしていないときは、削除ボタンが表示されない。
https://gyazo.com/24f0e2ae281a3a178cd66b7fea767baf